### PR TITLE
Fix parse_all metric code handling

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@ The Kolekti MetricFu gem implements a collector for Ruby metrics and issues usin
 
 == Unreleased
 
+* Fix metric code handling in parsers
 * Initial implementation of parsers and collector
 
 ===

--- a/lib/kolekti_metricfu/parsers.rb
+++ b/lib/kolekti_metricfu/parsers.rb
@@ -15,7 +15,8 @@ module KolektiMetricfu
       parsed_result = YAML.load_file(results_yaml_path)
 
       wanted_metric_configurations.each do |code, metric_configuration|
-        PARSERS[code].parse(parsed_result[code], metric_configuration, persistence_strategy)
+        code_sym = code.to_sym
+        PARSERS[code_sym].parse(parsed_result[code_sym], metric_configuration, persistence_strategy)
       end
     end
   end


### PR DESCRIPTION
It was assuming codes received in wanted metrics were symbols, but they
can be strings. Always convert to symbols to fix it.

Signed-off-by: Rafael Reggiani Manzo rr.manzo@protonmail.com
