### PR TITLE
Fix module name duplication for code with duplicate methods

### DIFF
--- a/features/collect_metrics.feature
+++ b/features/collect_metrics.feature
@@ -10,4 +10,14 @@ Feature: Collect Ruby metrics
     And I have a set of wanted metrics for all the supported ones
     And the "https://github.com/mezuro/kalibro_client.git" repository is cloned
     When I request Kolekti to collect the wanted metrics
-    And there should be metric results for all the wanted metrics
+    Then there should be metric results for all the wanted metrics
+
+  # This repository contains duplicate methods with the same name, which have caused problems in the past.
+  @unregister_collectors @clear_repository_dir
+  Scenario: Running, parsing and collecting results with strange cases
+    Given MetricFu is registered on Kolekti
+    And a persistence strategy is defined
+    And I have a set of wanted metrics for all the supported ones
+    And the "https://gitlab.com/noosfero/noosfero.git" repository is cloned with revision "1.3.2"
+    When I request Kolekti to collect the wanted metrics
+    Then there should be metric results for all the wanted metrics

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -1,8 +1,17 @@
 require 'tmpdir'
 
-Given(/^the "([^"]*)" repository is cloned$/) do |repository_url|
+def clone_repo(repository_url, revision=nil)
   @repository_path = Dir.mktmpdir
 
-  expect(system("git", "clone", "-q", repository_url, @repository_path, [:out, :err] => '/dev/null')).to be_truthy
+  cmd = ["git", "clone", "-q", "--depth", "1", repository_url, @repository_path]
+  cmd += ["-b", revision] if revision
+  expect(system(*cmd, [:out, :err] => '/dev/null')).to be_truthy
 end
 
+Given(/^the "([^"]*)" repository is cloned$/) do |repository_url|
+  clone_repo(repository_url)
+end
+
+Given(/^the "([^"]*)" repository is cloned with revision "([^"]*)"$/) do |repository_url, revision|
+  clone_repo(repository_url, revision)
+end

--- a/lib/kolekti_metricfu/parsers/base.rb
+++ b/lib/kolekti_metricfu/parsers/base.rb
@@ -3,8 +3,17 @@ module KolektiMetricfu
     class Base < Kolekti::Parser
       def self.module_name_suffix(module_name)
         return '' if module_name.to_s.end_with?("#none")
-        # Removing the self part of a static method to conform to flog's standard
-        return "." + module_name.to_s.gsub(/self\./, "").gsub(/#|::/, ".")
+
+        # Replace Saikuro's representation of a class method (#self.method) with Flog's
+        # (::method) so we can treat both the same later.
+        module_name = module_name.gsub('#self.', '::')
+        # Now split up the last component of the module name so it doesn't get it's
+        # prefixes (# or ::) replaced with . (our own separator).
+        module_path, prefix, module_name = module_name.rpartition(/#|::/)
+        # Replace the separators in the path (and only the path) with dots
+        module_path.gsub!(/#|::/, '.')
+        # Put everything back together
+        return '.' + module_path + '.' + prefix + module_name
       end
     end
   end

--- a/lib/kolekti_metricfu/parsers/flay.rb
+++ b/lib/kolekti_metricfu/parsers/flay.rb
@@ -3,14 +3,13 @@ module KolektiMetricfu
     class Flay < Base
       def self.parse(collected_metrics_hash, metric_configuration, persistence_strategy)
         collected_metrics_hash[:matches].each do |match|
-          results = []
           reason = match[:reason]
-          hotspot_metric_results = match[:matches].map do |line_match|
+          results = match[:matches].map do |line_match|
             line_number = line_match[:line].to_i
             module_name = parse_file_name(line_match[:name])
-            results << { 'module_name' => module_name,
-                         'line' => line_number,
-                         'message' => reason }
+            { 'module_name' => module_name,
+              'line' => line_number,
+              'message' => reason }
           end
 
           persistence_strategy.create_related_hotspot_metric_results(metric_configuration, results) unless results.empty?

--- a/lib/kolekti_metricfu/parsers/saikuro.rb
+++ b/lib/kolekti_metricfu/parsers/saikuro.rb
@@ -7,7 +7,9 @@ module KolektiMetricfu
           file[:classes].each do |cls|
             # Filter duplicate methods, picking only the latest. Fortunately Hash::[] will pick the latest element
             # when receiveing an array.
-            methods = Hash[cls[:methods].map { |method| [method[:name], method] }]
+            methods_by_name = cls[:methods].map { |method| [method[:name], method] }
+            # FIXME: Since ruby 2.1 this can be replaced by 'methods_by_name.to_hash'
+            methods = Hash[methods_by_name]
             methods.each_value do |method|
               value = method[:complexity]
               name_suffix = module_name_suffix(method[:name])

--- a/lib/kolekti_metricfu/parsers/saikuro.rb
+++ b/lib/kolekti_metricfu/parsers/saikuro.rb
@@ -2,8 +2,6 @@ module KolektiMetricfu
   module Parsers
     class Saikuro < Base
       def self.parse(collected_metrics_hash, metric_configuration, persistence_strategy)
-
-
         collected_metrics_hash[:files].each do |file|
           name_prefix = parse_file_name(file[:filename])
           file[:classes].each do |cls|

--- a/lib/kolekti_metricfu/parsers/saikuro.rb
+++ b/lib/kolekti_metricfu/parsers/saikuro.rb
@@ -2,13 +2,19 @@ module KolektiMetricfu
   module Parsers
     class Saikuro < Base
       def self.parse(collected_metrics_hash, metric_configuration, persistence_strategy)
+
+
         collected_metrics_hash[:files].each do |file|
           name_prefix = parse_file_name(file[:filename])
-          file[:classes].each do |clazz|
-            clazz[:methods].each do |method|
+          file[:classes].each do |cls|
+            # Filter duplicate methods, picking only the latest. Fortunately Hash::[] will pick the latest element
+            # when receiveing an array.
+            methods = Hash[cls[:methods].map { |method| [method[:name], method] }]
+            methods.each_value do |method|
               value = method[:complexity]
               name_suffix = module_name_suffix(method[:name])
               module_name = name_prefix + name_suffix
+
               granularity = KalibroClient::Entities::Miscellaneous::Granularity::METHOD
               persistence_strategy.create_tree_metric_result(metric_configuration, module_name, value.to_f, granularity)
             end

--- a/spec/factories/metric_fu_results.rb
+++ b/spec/factories/metric_fu_results.rb
@@ -17,6 +17,11 @@ FactoryGirl.define do
                :operators => {:perform_later=>1.1},
                :score => 2.0,
                :path => "app/models/repository.rb:30"},
+             # Intentionally duplicated
+             "Repository#reprocess"=>{
+               :operators => {:perform_later=>1.1},
+               :score => 3.0,
+               :path => "app/models/repository.rb:30"},
              "main#none" => {
                :operators=>{:require=>36.20000000000003},
                :score=>3.0,
@@ -33,6 +38,10 @@ FactoryGirl.define do
                 :methods => [
                   { :name => "Repository#reprocess",
                     :complexity => 5,
+                    :lines => 10},
+                  # Intentionally duplicated
+                  { :name => "Repository#reprocess",
+                    :complexity => 10,
                     :lines => 10},
                   { :name => "Repository#process",
                     :complexity => 10,

--- a/spec/factories/metric_fu_results.rb
+++ b/spec/factories/metric_fu_results.rb
@@ -17,11 +17,6 @@ FactoryGirl.define do
                :operators => {:perform_later=>1.1},
                :score => 2.0,
                :path => "app/models/repository.rb:30"},
-             # Intentionally duplicated
-             "Repository#reprocess"=>{
-               :operators => {:perform_later=>1.1},
-               :score => 3.0,
-               :path => "app/models/repository.rb:30"},
              "main#none" => {
                :operators=>{:require=>36.20000000000003},
                :score=>3.0,

--- a/spec/parsers/base_spec.rb
+++ b/spec/parsers/base_spec.rb
@@ -9,9 +9,12 @@ describe KolektiMetricfu::Parsers::Base do
     describe 'module_name_suffix' do
       cases = {
         'module#none' => '',
-        'self.method' => '.method',
-        'Class#method' => '.Class.method',
-        'Module::Class#self.method' => '.Module.Class.method'
+        'Class#method' => '.Class.#method',
+        'Class::method' => '.Class.::method',
+        'Class#self.method' => '.Class.::method',
+        'Module::Class#method' => '.Module.Class.#method',
+        'Module::Class#self.method' => '.Module.Class.::method',
+        'Module::Class::method' => '.Module.Class.::method'
       }
 
       cases.each do |input, output|

--- a/spec/parsers/flog_spec.rb
+++ b/spec/parsers/flog_spec.rb
@@ -18,8 +18,13 @@ describe KolektiMetricfu::Parsers::Flog do
         expect(described_class).to receive(:module_name_suffix).with('Repository#process'){ '.Repository.process' }
         expect(described_class).to receive(:module_name_suffix).with('Repository#reprocess'){ '.Repository.reprocess' }
 
-        expect(persistence_strategy).to receive(:create_tree_metric_result).with(metric_configuration, 'app.models.repository.Repository.process', 1.1, KalibroClient::Entities::Miscellaneous::Granularity::METHOD)
-        expect(persistence_strategy).to receive(:create_tree_metric_result).with(metric_configuration, 'app.models.repository.Repository.reprocess', 2.0, KalibroClient::Entities::Miscellaneous::Granularity::METHOD)
+        granularity = KalibroClient::Entities::Miscellaneous::Granularity::METHOD
+        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
+          metric_configuration, 'app.models.repository.Repository.process', 1.1, granularity)
+        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
+          metric_configuration, 'app.models.repository.Repository.reprocess', 3.0, granularity)
+        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
+          metric_configuration, 'app.models.repository.Repository.reprocess', 2.0, granularity).never
 
         described_class.parse(flog_results, metric_configuration, persistence_strategy)
       end

--- a/spec/parsers/flog_spec.rb
+++ b/spec/parsers/flog_spec.rb
@@ -22,9 +22,7 @@ describe KolektiMetricfu::Parsers::Flog do
         expect(persistence_strategy).to receive(:create_tree_metric_result).with(
           metric_configuration, 'app.models.repository.Repository.process', 1.1, granularity)
         expect(persistence_strategy).to receive(:create_tree_metric_result).with(
-          metric_configuration, 'app.models.repository.Repository.reprocess', 3.0, granularity)
-        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
-          metric_configuration, 'app.models.repository.Repository.reprocess', 2.0, granularity).never
+          metric_configuration, 'app.models.repository.Repository.reprocess', 2.0, granularity)
 
         described_class.parse(flog_results, metric_configuration, persistence_strategy)
       end

--- a/spec/parsers/saikuro_spec.rb
+++ b/spec/parsers/saikuro_spec.rb
@@ -17,8 +17,13 @@ describe KolektiMetricfu::Parsers::Saikuro do
         expect(described_class).to receive(:module_name_suffix).with('Repository#process'){ '.Repository.process' }
         expect(described_class).to receive(:module_name_suffix).with('Repository#reprocess'){ '.Repository.reprocess' }
 
-        expect(persistence_strategy).to receive(:create_tree_metric_result).with(metric_configuration, 'app.models.repository.Repository.reprocess', 5.0, KalibroClient::Entities::Miscellaneous::Granularity::METHOD)
-        expect(persistence_strategy).to receive(:create_tree_metric_result).with(metric_configuration, 'app.models.repository.Repository.process', 10.0, KalibroClient::Entities::Miscellaneous::Granularity::METHOD)
+        granularity = KalibroClient::Entities::Miscellaneous::Granularity::METHOD
+        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
+          metric_configuration, 'app.models.repository.Repository.reprocess', 10.0, granularity)
+        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
+          metric_configuration, 'app.models.repository.Repository.reprocess', 5.0, granularity).never
+        expect(persistence_strategy).to receive(:create_tree_metric_result).with(
+          metric_configuration, 'app.models.repository.Repository.process', 10.0, granularity)
 
         described_class.parse(saikuro_results, metric_configuration, persistence_strategy)
       end


### PR DESCRIPTION
The Noosfero repository contains strange code such as methods declared multiple times in the
same class, or declared as both instance and class methods. It can be a
good check for our corner case handling.

Add an acceptance test using it and fix the bugs found in the process.
