### PR TITLE
Create a cache for bundler on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 rvm:
   - 2.3.0
 
+cache: bundler
+
 before_install: gem install bundler -v 1.11.2
 
 notifications:


### PR DESCRIPTION
This should speed up our builds, since most of times we won't need to
install all the gems.
