### PR TITLE
Fix ruby backwards compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 
 rvm:
   - 2.3.0
+  - 2.0.0-p598 # CentOS 7
+  - 2.1.5 # Debian 8
 
 cache: bundler
 

--- a/gem_tasks/cucumber.rake
+++ b/gem_tasks/cucumber.rake
@@ -3,25 +3,8 @@
 require 'cucumber/rake/task'
 require 'cucumber/platform'
 
-class Cucumber::Rake::Task
-  def set_profile_for_current_ruby
-    self.profile = if Cucumber::JRUBY
-      Cucumber::WINDOWS ? 'jruby_win' : 'jruby'
-    elsif Cucumber::WINDOWS_MRI
-      'windows_mri'
-    elsif Cucumber::RUBY_1_9
-      'ruby_1_9'
-    elsif Cucumber::RUBY_2_0
-      'ruby_2_0'
-    elsif Cucumber::RUBY_2_1
-      'ruby_2_1'
-    end
-  end
-end
-
 Cucumber::Rake::Task.new(:features) do |t|
   t.fork = true
-  t.set_profile_for_current_ruby
 end
 
 task cucumber: :features

--- a/lib/kolekti/metricfu/collector.rb
+++ b/lib/kolekti/metricfu/collector.rb
@@ -4,7 +4,9 @@ module Kolekti
   module Metricfu
     class Collector < Kolekti::Collector
       def self.available?
-        system('metric_fu --version', [:out, :err] => '/dev/null') ? true : false
+        # FIXME: below is the better form of writing this, but it does not look compatible with ruby 2.1.5 and 2.0.0
+        # system('metric_fu --version', [:out, :err] => '/dev/null') ? true : false
+        system('metric_fu --version', out: '/dev/null', err: '/dev/null') ? true : false
       end
 
       def initialize

--- a/lib/kolekti/metricfu/collector.rb
+++ b/lib/kolekti/metricfu/collector.rb
@@ -23,7 +23,7 @@ module Kolekti
         tmp_file = Tempfile.new(['metric_fu', '.yml'], code_directory)
         begin
           Dir.chdir(code_directory) do
-            unless system('metric_fu', '--format', 'yaml', '--out', tmp_file.path, [:out, :err] => '/dev/null')
+            unless system('metric_fu', '--format', 'yaml', '--out', tmp_file.path, out: '/dev/null', err: '/dev/null')
               raise Kolekti::CollectorError.new('MetricFu failed')
             end
           end

--- a/lib/kolekti/metricfu/collector.rb
+++ b/lib/kolekti/metricfu/collector.rb
@@ -23,7 +23,7 @@ module Kolekti
         tmp_file = Tempfile.new(['metric_fu', '.yml'], code_directory)
         begin
           Dir.chdir(code_directory) do
-            unless system('metric_fu', '--format', 'yaml', '--out', tmp_file.path, out: '/dev/null', err: '/dev/null')
+            unless system('metric_fu', '--format', 'yaml', '--out', tmp_file.path, '--no-reek', out: '/dev/null', err: '/dev/null')
               raise Kolekti::CollectorError.new('MetricFu failed')
             end
           end

--- a/spec/kolekti/metricfu/collector_spec.rb
+++ b/spec/kolekti/metricfu/collector_spec.rb
@@ -49,7 +49,7 @@ describe Kolekti::Metricfu::Collector do
       let(:wanted_metric_configurations) { double }
       let(:persistence_strategy) { double }
       let(:metric_fu_params) {
-        ['metric_fu', '--format', 'yaml', '--out', output_path, [:out, :err] => '/dev/null']
+        ['metric_fu', '--format', 'yaml', '--out', output_path, out: '/dev/null', err: '/dev/null']
       }
 
       before :each do

--- a/spec/kolekti/metricfu/collector_spec.rb
+++ b/spec/kolekti/metricfu/collector_spec.rb
@@ -5,7 +5,7 @@ describe Kolekti::Metricfu::Collector do
     describe 'available?' do
       context 'with a successful call (system exit 0)' do
         it 'is expected to call the system executable and return true' do
-          expect(described_class).to receive(:system).with('metric_fu --version', [:out, :err] => '/dev/null') { true }
+          expect(described_class).to receive(:system).with('metric_fu --version', out: '/dev/null', err: '/dev/null') { true }
 
           expect(described_class.available?).to be_truthy
         end
@@ -13,7 +13,7 @@ describe Kolekti::Metricfu::Collector do
 
       context 'with a failed call to system executable (it is not installed)' do
         it 'is expected to call the system executable and return false' do
-          expect(described_class).to receive(:system).with('metric_fu --version', [:out, :err] => '/dev/null') { nil }
+          expect(described_class).to receive(:system).with('metric_fu --version', out: '/dev/null', err: '/dev/null') { nil }
 
           expect(described_class.available?).to be_falsey
         end
@@ -21,7 +21,7 @@ describe Kolekti::Metricfu::Collector do
 
       context 'with a errored call to system executable (it is installed but not working: non-zero exit)' do
         it 'is expected to call the system executable and return false' do
-          expect(described_class).to receive(:system).with('metric_fu --version', [:out, :err] => '/dev/null') { false }
+          expect(described_class).to receive(:system).with('metric_fu --version', out: '/dev/null', err: '/dev/null') { false }
 
           expect(described_class.available?).to be_falsey
         end

--- a/spec/kolekti/metricfu/collector_spec.rb
+++ b/spec/kolekti/metricfu/collector_spec.rb
@@ -49,7 +49,7 @@ describe Kolekti::Metricfu::Collector do
       let(:wanted_metric_configurations) { double }
       let(:persistence_strategy) { double }
       let(:metric_fu_params) {
-        ['metric_fu', '--format', 'yaml', '--out', output_path, out: '/dev/null', err: '/dev/null']
+        ['metric_fu', '--format', 'yaml', '--out', output_path, '--no-reek', out: '/dev/null', err: '/dev/null']
       }
 
       before :each do


### PR DESCRIPTION
Prezento's build https://travis-ci.org/mezuro/prezento/builds/129486939 revealed this flaw.

We add those versions to travis' build matrix in order to avoid this in the future.
