### PR TITLE
Restrict flog version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ using MetricFu
 ## Unreleased
 
 * Prevent incompatible versions of metric_fu and flog to get installed together
+ - That issue is being worked on by the metric_fu people, so this change will be
+ reverted as soon as that is fixed.
 
 ## v0.0.3 - 16/05/2016
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ using MetricFu
 
 ## Unreleased
 
+* Prevent incompatible versions of metric_fu and flog to get installed together
+
 ## v0.0.3 - 16/05/2016
 
 * Add backwards compatibility up to ruby 2.0.0-p594 (CentOS 7 version)

--- a/kolekti_metricfu.gemspec
+++ b/kolekti_metricfu.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'kolekti', '~> 1.1'
   spec.add_dependency 'metric_fu', '~> 4.12.0'
+  spec.add_dependency 'flog', '~> 4.3.2' # Restriction necessary until https://github.com/metricfu/metric_fu/pull/274 does not get merged, released and we update our metric_fu requirements
   # Version 0.2.5 requires ruby >= 2.1 while CentOS 7 is still running 2.0.0
   spec.add_dependency 'unparser', '< 0.2.5' if RUBY_VERSION < '2.1.0'
 


### PR DESCRIPTION
The newer version (4.4.0) modifies the API and breaks MetricFu. This is
getting addressed by https://github.com/metricfu/metric_fu/pull/274.

For now we restrict the flog version until a new MetricFu release gets
out.

This should fix the build https://travis-ci.org/mezuro/kolekti_metricfu/builds/134510725

Signed-off-by: Eduardo Araújo duduktamg@hotmail.com
